### PR TITLE
Allow argument missmatch to Makefile (for ubuntu and fedora)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ MPIF90  = mpiifort -DMPI $(SFLAGS)
 #
 SFLAGSg = -fdefault-integer-8 -fdefault-real-8 -fdefault-double-8 -cpp -ffpe-summary=none -O3
 F90g    = gfortran     $(SFLAGSg) 
-MPIF90g = mpif90 -DMPI $(SFLAGSg)
+MPIF90g = mpif90 -DMPI -fallow-argument-mismatch $(SFLAGSg)
 #
 ###############################################################################################
 


### PR DESCRIPTION
To compile mpig in ubuntu and fedora